### PR TITLE
Actualizar paleta de colores y encabezados

### DIFF
--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -10,7 +10,7 @@
   <meta name="keywords" content="Feria de Agosto, Antequera, 2025, casetas, toros, conciertos, programa, concursos, Málaga, Andalucía, fiesta, tradición" />
   <meta name="author" content="Q de Qultura" />
   <meta name="robots" content="index, follow" />
-  <meta name="theme-color" content="#8B1A1A" />
+  <meta name="theme-color" content="#282284" />
   
   <!-- Canonical URL -->
   <link rel="canonical" href="https://feria.antequera.click{{ page.url | url }}" />

--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,10 @@
 /* Reset y base */
+:root {
+  --color-primary: #282284;
+  --color-secondary: #d41920;
+  --color-accent: #f1d142;
+}
+
 * {
   margin: 0;
   padding: 0;
@@ -8,7 +14,7 @@
 body {
   font-family: 'Lato', sans-serif;
   line-height: 1.6;
-  background: linear-gradient(135deg, #8B1A1A 0%, #D4AF37 50%, #8B1A1A 100%);
+  background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-accent) 50%, var(--color-primary) 100%);
   min-height: 100vh;
   color: #333;
 }
@@ -19,10 +25,25 @@ body {
   flex-direction: column;
 }
 
+/* Heading styles */
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Bebas Neue', sans-serif;
+  color: var(--color-primary);
+  line-height: 1.2;
+  margin: 1.5rem 0 1rem;
+}
+
+h1 { font-size: 2.5rem; }
+h2 { font-size: 2rem; }
+h3 { font-size: 1.75rem; }
+h4 { font-size: 1.5rem; }
+h5 { font-size: 1.25rem; }
+h6 { font-size: 1rem; }
+
 /* Header heroico */
 .hero-header {
-  background: linear-gradient(rgba(139, 26, 26, 0.9), rgba(139, 26, 26, 0.8)),
-              url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><defs><pattern id="confetti" x="0" y="0" width="20" height="20" patternUnits="userSpaceOnUse"><circle cx="2" cy="2" r="1" fill="%23FFD700" opacity="0.3"/><circle cx="18" cy="8" r="1" fill="%23FF6B6B" opacity="0.3"/><circle cx="10" cy="15" r="1" fill="%23FFD700" opacity="0.3"/></pattern></defs><rect width="100" height="100" fill="url(%23confetti)"/></svg>');
+  background: linear-gradient(rgba(40, 34, 132, 0.9), rgba(40, 34, 132, 0.8)),
+              url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><defs><pattern id="confetti" x="0" y="0" width="20" height="20" patternUnits="userSpaceOnUse"><circle cx="2" cy="2" r="1" fill="%23F1D142" opacity="0.3"/><circle cx="18" cy="8" r="1" fill="%23FF6B6B" opacity="0.3"/><circle cx="10" cy="15" r="1" fill="%23F1D142" opacity="0.3"/></pattern></defs><rect width="100" height="100" fill="url(%23confetti)"/></svg>');
   color: white;
   text-align: center;
   padding: 2rem 1.5rem 1.5rem;
@@ -37,8 +58,8 @@ body {
   left: 0;
   right: 0;
   bottom: 0;
-  background: radial-gradient(circle at 30% 20%, rgba(255, 215, 0, 0.2) 0%, transparent 50%),
-              radial-gradient(circle at 70% 80%, rgba(255, 107, 107, 0.2) 0%, transparent 50%);
+  background: radial-gradient(circle at 30% 20%, rgba(241, 209, 66, 0.2) 0%, transparent 50%),
+              radial-gradient(circle at 70% 80%, rgba(212, 25, 32, 0.2) 0%, transparent 50%);
   pointer-events: none;
 }
 
@@ -58,7 +79,7 @@ body {
   font-family: 'Dancing Script', cursive;
   font-size: clamp(1.8rem, 6vw, 3rem);
   text-decoration: none;
-  color: #FFD700;
+  color: var(--color-accent);
   text-shadow: 3px 3px 6px rgba(0, 0, 0, 0.5);
   letter-spacing: 2px;
   display: inline-block;
@@ -71,15 +92,15 @@ body {
 }
 
 .year-badge {
-  background: linear-gradient(45deg, #FFD700, #FFA500);
-  color: #8B1A1A;
+  background: linear-gradient(45deg, var(--color-accent), var(--color-secondary));
+  color: var(--color-secondary);
   font-weight: bold;
   font-size: 1.2rem;
   padding: 0.5rem 1rem;
   border-radius: 50px;
   display: inline-block;
   margin-top: 0.5rem;
-  box-shadow: 0 4px 15px rgba(255, 215, 0, 0.3);
+  box-shadow: 0 4px 15px rgba(241, 209, 66, 0.3);
   animation: pulse 2s infinite;
 }
 
@@ -99,7 +120,7 @@ body {
 .location {
   font-family: 'Dancing Script', cursive;
   font-size: 2rem;
-  color: #FFD700;
+  color: var(--color-accent);
   text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
 }
 
@@ -163,7 +184,7 @@ body {
 .menu-toggle span {
   width: 25px;
   height: 3px;
-  background: #8B1A1A;
+  background: var(--color-primary);
   transition: all 0.3s ease;
 }
 
@@ -186,7 +207,7 @@ body {
   align-items: center;
   gap: 0.5rem;
   padding: 1.2rem 1.5rem;
-  color: #8B1A1A;
+  color: var(--color-primary);
   text-decoration: none;
   font-weight: 600;
   font-size: 1rem;
@@ -207,14 +228,14 @@ body {
   left: 50%;
   width: 0;
   height: 3px;
-  background: linear-gradient(90deg, #FFD700, #FFA500);
+  background: linear-gradient(90deg, var(--color-accent), var(--color-secondary));
   transition: all 0.3s ease;
   transform: translateX(-50%);
 }
 
 .nav-link:hover {
-  color: #8B1A1A;
-  background: rgba(255, 215, 0, 0.1);
+  color: var(--color-secondary);
+  background: rgba(241, 209, 66, 0.1);
 }
 
 .nav-link:hover::before {
@@ -255,12 +276,12 @@ body {
 .submenu-link {
   display: block;
   padding: 0.8rem 1.5rem;
-  color: #8B1A1A;
+  color: var(--color-primary);
   text-decoration: none;
   font-weight: 500;
   font-size: 0.9rem;
   transition: all 0.3s ease;
-  border-bottom: 1px solid rgba(139, 26, 26, 0.1);
+  border-bottom: 1px solid rgba(40, 34, 132, 0.1);
 }
 
 .submenu-link:last-child {
@@ -268,8 +289,8 @@ body {
 }
 
 .submenu-link:hover {
-  background: rgba(255, 215, 0, 0.1);
-  color: #8B1A1A;
+  background: rgba(241, 209, 66, 0.1);
+  color: var(--color-secondary);
   padding-left: 2rem;
 }
 
@@ -302,8 +323,8 @@ body {
 }
 
 .content-wrapper h2 {
-  color: #8B1A1A;
-  font-family: 'Archivo Black', sans-serif;
+  color: var(--color-primary);
+  font-family: 'Bebas Neue', sans-serif;
   font-size: 2.5rem;
   margin-bottom: 1.5rem;
   text-align: center;
@@ -318,7 +339,7 @@ body {
   transform: translateX(-50%);
   width: 100px;
   height: 4px;
-  background: linear-gradient(90deg, #FFD700, #FFA500);
+  background: linear-gradient(90deg, var(--color-accent), var(--color-secondary));
   border-radius: 2px;
 }
 
@@ -331,12 +352,12 @@ body {
 
 /* Elementos destacados */
 .destacados {
-  background: linear-gradient(135deg, rgba(255, 215, 0, 0.1), rgba(255, 165, 0, 0.1));
+  background: linear-gradient(135deg, rgba(241, 209, 66, 0.1), rgba(212, 25, 32, 0.1));
   margin: 2rem 0;
   padding: 2rem;
   border-radius: 15px;
-  border-left: 5px solid #FFD700;
-  box-shadow: 0 4px 15px rgba(255, 215, 0, 0.2);
+  border-left: 5px solid var(--color-accent);
+  box-shadow: 0 4px 15px rgba(241, 209, 66, 0.2);
 }
 
 .evento {
@@ -357,7 +378,7 @@ body {
 }
 
 .ver-programa a {
-  background: linear-gradient(45deg, #8B1A1A, #B22222);
+  background: linear-gradient(45deg, var(--color-primary), var(--color-secondary));
   color: white;
   padding: 1rem 2rem;
   text-decoration: none;
@@ -365,17 +386,17 @@ body {
   font-weight: bold;
   display: inline-block;
   transition: all 0.3s ease;
-  box-shadow: 0 4px 15px rgba(139, 26, 26, 0.3);
+  box-shadow: 0 4px 15px rgba(40, 34, 132, 0.3);
 }
 
 .ver-programa a:hover {
   transform: translateY(-2px);
-  box-shadow: 0 6px 20px rgba(139, 26, 26, 0.4);
+  box-shadow: 0 6px 20px rgba(40, 34, 132, 0.4);
 }
 
 /* Footer */
 .site-footer {
-  background: linear-gradient(135deg, #8B1A1A, #B22222);
+  background: linear-gradient(135deg, var(--color-primary), var(--color-secondary));
   color: white;
   padding: 2rem;
   margin-top: auto;
@@ -391,12 +412,12 @@ body {
 }
 
 .footer-section h3 {
-  font-family: 'Archivo Black', sans-serif;
-  color: #FFD700;
+  font-family: 'Bebas Neue', sans-serif;
+  color: var(--color-accent);
   margin-bottom: 0.5rem;
 }
 .footer-section a{
-    color: #FFD700;
+    color: var(--color-accent);
     text-decoration: none;
 }
 
@@ -406,7 +427,7 @@ body {
 
 .year {
   font-style: italic;
-  color: #FFD700;
+  color: var(--color-accent);
 }
 
 /* Responsive Design */
@@ -452,7 +473,7 @@ body {
   .nav-link {
     justify-content: center;
     padding: 1rem;
-    border-bottom: 1px solid rgba(139, 26, 26, 0.1);
+    border-bottom: 1px solid rgba(40, 34, 132, 0.1);
   }
   
   .submenu {
@@ -462,7 +483,7 @@ body {
     transform: none;
     box-shadow: none;
     backdrop-filter: none;
-    background: rgba(255, 215, 0, 0.1);
+    background: rgba(241, 209, 66, 0.1);
     border-radius: 0;
     max-height: 0;
     overflow: hidden;
@@ -476,7 +497,7 @@ body {
   .submenu-link {
     padding: 0.8rem 2rem;
     font-size: 0.85rem;
-    border-bottom: 1px solid rgba(139, 26, 26, 0.05);
+    border-bottom: 1px solid rgba(40, 34, 132, 0.05);
   }
   
   .submenu-link:hover {
@@ -544,13 +565,13 @@ li {
   right: 30px;
   width: 50px;
   height: 50px;
-  background: linear-gradient(45deg, #8B1A1A, #B22222);
+  background: linear-gradient(45deg, var(--color-primary), var(--color-secondary));
   color: white;
   border: none;
   border-radius: 50%;
   cursor: pointer;
   font-size: 1.5rem;
-  box-shadow: 0 4px 15px rgba(139, 26, 26, 0.3);
+  box-shadow: 0 4px 15px rgba(40, 34, 132, 0.3);
   opacity: 0;
   visibility: hidden;
   transform: translateY(20px);
@@ -565,9 +586,9 @@ li {
 }
 
 .scroll-to-top:hover {
-  background: linear-gradient(45deg, #B22222, #8B1A1A);
+  background: linear-gradient(45deg, var(--color-secondary), var(--color-primary));
   transform: translateY(-2px);
-  box-shadow: 0 6px 20px rgba(139, 26, 26, 0.4);
+  box-shadow: 0 6px 20px rgba(40, 34, 132, 0.4);
 }
 
 .scroll-to-top:active {
@@ -587,18 +608,18 @@ li {
 /* Content Links Styling */
 .content-wrapper a,
 .main-content a {
-  color: #8B1A1A;
+  color: var(--color-primary);
   text-decoration: none;
   font-weight: 600;
   position: relative;
   transition: all 0.3s ease;
-  border-bottom: 2px solid rgba(139, 26, 26, 0.3);
+  border-bottom: 2px solid rgba(40, 34, 132, 0.3);
 }
 
 .content-wrapper a:hover,
 .main-content a:hover {
-  color: #B22222;
-  border-bottom-color: #FFD700;
+  color: var(--color-secondary);
+  border-bottom-color: var(--color-accent);
 }
 
 /* External links icon */
@@ -609,7 +630,7 @@ li {
   width: 12px;
   height: 12px;
   margin-left: 4px;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%238B1A1A' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' d='M8.636 3.5a.5.5 0 0 0-.5-.5H1.5A1.5 1.5 0 0 0 0 4.5v10A1.5 1.5 0 0 0 1.5 16h10a1.5 1.5 0 0 0 1.5-1.5V7.864a.5.5 0 0 0-1 0V14.5a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h6.636a.5.5 0 0 0 .5-.5z'/%3E%3Cpath fill-rule='evenodd' d='M16 .5a.5.5 0 0 0-.5-.5h-5a.5.5 0 0 0 0 1h3.793L6.146 9.146a.5.5 0 1 0 .708.708L15 1.707V5.5a.5.5 0 0 0 1 0v-5z'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23282284' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' d='M8.636 3.5a.5.5 0 0 0-.5-.5H1.5A1.5 1.5 0 0 0 0 4.5v10A1.5 1.5 0 0 0 1.5 16h10a1.5 1.5 0 0 0 1.5-1.5V7.864a.5.5 0 0 0-1 0V14.5a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h6.636a.5.5 0 0 0 .5-.5z'/%3E%3Cpath fill-rule='evenodd' d='M16 .5a.5.5 0 0 0-.5-.5h-5a.5.5 0 0 0 0 1h3.793L6.146 9.146a.5.5 0 1 0 .708.708L15 1.707V5.5a.5.5 0 0 0 1 0v-5z'/%3E%3C/svg%3E");
   background-size: contain;
   background-repeat: no-repeat;
   vertical-align: text-top;
@@ -623,7 +644,7 @@ li {
   width: 14px;
   height: 14px;
   margin-right: 6px;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%238B1A1A' viewBox='0 0 16 16'%3E%3Cpath d='M3.654 1.328a.678.678 0 0 0-1.015-.063L1.605 2.3c-.483.484-.661 1.169-.45 1.77a17.568 17.568 0 0 0 4.168 6.608 17.569 17.569 0 0 0 6.608 4.168c.601.211 1.286.033 1.77-.45l1.034-1.034a.678.678 0 0 0-.063-1.015l-2.307-1.794a.678.678 0 0 0-.58-.122L9.98 10.48c-.377.109-.673.425-.757.823a.678.678 0 0 1-.804.499l-1.372-.343a9.552 9.552 0 0 1-3.861-2.708 9.552 9.552 0 0 1-2.708-3.861l-.343-1.372a.678.678 0 0 1 .499-.804c.398-.084.714-.38.823-.757l.131-1.805a.678.678 0 0 0-.122-.58L3.654 1.328z'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23282284' viewBox='0 0 16 16'%3E%3Cpath d='M3.654 1.328a.678.678 0 0 0-1.015-.063L1.605 2.3c-.483.484-.661 1.169-.45 1.77a17.568 17.568 0 0 0 4.168 6.608 17.569 17.569 0 0 0 6.608 4.168c.601.211 1.286.033 1.77-.45l1.034-1.034a.678.678 0 0 0-.063-1.015l-2.307-1.794a.678.678 0 0 0-.58-.122L9.98 10.48c-.377.109-.673.425-.757.823a.678.678 0 0 1-.804.499l-1.372-.343a9.552 9.552 0 0 1-3.861-2.708 9.552 9.552 0 0 1-2.708-3.861l-.343-1.372a.678.678 0 0 1 .499-.804c.398-.084.714-.38.823-.757l.131-1.805a.678.678 0 0 0-.122-.58L3.654 1.328z'/%3E%3C/svg%3E");
   background-size: contain;
   background-repeat: no-repeat;
   vertical-align: text-top;
@@ -637,7 +658,7 @@ li {
   width: 14px;
   height: 14px;
   margin-right: 6px;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%238B1A1A' viewBox='0 0 16 16'%3E%3Cpath d='M.05 3.555A2 2 0 0 1 2 2h12a2 2 0 0 1 1.95 1.555L8 8.414.05 3.555zM0 4.697v7.104l5.803-3.558L0 4.697zM6.761 8.83l-6.57 4.027A2 2 0 0 0 2 14h12a2 2 0 0 0 1.808-1.144l-6.57-4.027L8 9.586l-1.239-.757zm3.436-.586L16 11.801V4.697l-5.803 3.546z'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23282284' viewBox='0 0 16 16'%3E%3Cpath d='M.05 3.555A2 2 0 0 1 2 2h12a2 2 0 0 1 1.95 1.555L8 8.414.05 3.555zM0 4.697v7.104l5.803-3.558L0 4.697zM6.761 8.83l-6.57 4.027A2 2 0 0 0 2 14h12a2 2 0 0 0 1.808-1.144l-6.57-4.027L8 9.586l-1.239-.757zm3.436-.586L16 11.801V4.697l-5.803 3.546z'/%3E%3C/svg%3E");
   background-size: contain;
   background-repeat: no-repeat;
   vertical-align: text-top;

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -4,7 +4,7 @@
   "description": "Feria de Agosto 2025 en Antequera del 20 al 24 de agosto",
   "start_url": "/",
   "display": "standalone",
-  "theme_color": "#8B1A1A",
+  "theme_color": "#282284",
   "background_color": "#ffffff",
   "orientation": "portrait-primary",
   "icons": [


### PR DESCRIPTION
## Resumen
- Implementa variables CSS con la nueva paleta `#282284`, `#d41920` y `#f1d142`
- Añade estilos coherentes para los encabezados `h1` a `h6`
- Ajusta meta y manifest para reflejar el nuevo color del tema

## Pruebas
- `node node_modules/@11ty/eleventy/cmd.cjs`

------
https://chatgpt.com/codex/tasks/task_e_689784b3f17c8330a0d4a1a81b5dc6c8