### PR TITLE
Add sitemap and robots files

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -5,7 +5,9 @@ module.exports = function (eleventyConfig) {
 	eleventyConfig.addPassthroughCopy('site.webmanifest'); // Copia el manifest
 	eleventyConfig.addPassthroughCopy('*.ico'); // Copia favicons
 	eleventyConfig.addPassthroughCopy('*.png'); // Copia iconos PNG
-	eleventyConfig.addPassthroughCopy('images'); // Copia imágenes
+        eleventyConfig.addPassthroughCopy('images'); // Copia imágenes
+        eleventyConfig.addPassthroughCopy('robots.txt'); // Copia robots.txt
+        eleventyConfig.addPassthroughCopy('sitemap.xml'); // Copia sitemap
 	eleventyConfig.ignores.add('CLAUDE.md'); // o el archivo que quieras ignorar
 	eleventyConfig.ignores.add('README.md'); // o el archivo que quieras ignorar
 	eleventyConfig.addGlobalData('layout', 'layout.njk');

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://feria.antequera.click/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://feria.antequera.click/</loc></url>
+  <url><loc>https://feria.antequera.click/casetas/</loc></url>
+  <url><loc>https://feria.antequera.click/concursos/</loc></url>
+  <url><loc>https://feria.antequera.click/concursos/caballos/</loc></url>
+  <url><loc>https://feria.antequera.click/concursos/porra/</loc></url>
+  <url><loc>https://feria.antequera.click/concursos/trajes/</loc></url>
+  <url><loc>https://feria.antequera.click/legal/</loc></url>
+  <url><loc>https://feria.antequera.click/mapas/</loc></url>
+  <url><loc>https://feria.antequera.click/programa/2025-08-20/</loc></url>
+  <url><loc>https://feria.antequera.click/programa/2025-08-21/</loc></url>
+  <url><loc>https://feria.antequera.click/programa/2025-08-22/</loc></url>
+  <url><loc>https://feria.antequera.click/programa/2025-08-23/</loc></url>
+  <url><loc>https://feria.antequera.click/programa/2025-08-24/</loc></url>
+  <url><loc>https://feria.antequera.click/servicios/atracciones/</loc></url>
+  <url><loc>https://feria.antequera.click/servicios/feria-sin-ruido/</loc></url>
+  <url><loc>https://feria.antequera.click/servicios/telefonos/</loc></url>
+  <url><loc>https://feria.antequera.click/servicios/tren-turistico/</loc></url>
+  <url><loc>https://feria.antequera.click/toros/</loc></url>
+</urlset>


### PR DESCRIPTION
## Summary
- add robots.txt exposing sitemap
- include manual sitemap.xml covering all festival pages
- update Eleventy config to passthrough sitemap and robots files

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6897c1c5c3508330bcc0aae21a9191f7