### PR TITLE
Usa Font Awesome en lugar de Bootstrap Icons

### DIFF
--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">  
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
   <!-- SEO Meta Tags -->
   <title>{{ title or 'Feria de Agosto 2025 - Antequera' }}</title>
   <meta name="description" content="{{ description or 'Feria de Agosto 2025 en Antequera del 20 al 24 de agosto. Programa completo, casetas, conciertos, toros, concursos y servicios. La gran fiesta del verano antequerano.' }}" />
@@ -131,7 +131,7 @@
         </button>
         <ul class="nav-menu">
           <li class="nav-item has-submenu">
-            <a href="#" class="nav-link"><i class="bi bi-calendar-event"></i> Programa</a>
+            <a href="#" class="nav-link"><i class="fa-solid fa-calendar-days"></i> Programa</a>
             <ul class="submenu">
               <li><a href="/programa/2025-08-20/" class="submenu-link">Miércoles 20 agosto</a></li>
               <li><a href="/programa/2025-08-21/" class="submenu-link">Jueves 21 agosto</a></li>
@@ -140,15 +140,15 @@
               <li><a href="/programa/2025-08-24/" class="submenu-link">Domingo 24 agosto</a></li>
             </ul>
           </li>
-          <li><a href="/casetas/" class="nav-link"><i class="bi bi-house-door"></i> Casetas</a></li>
+          <li><a href="/casetas/" class="nav-link"><i class="fa-solid fa-house"></i> Casetas</a></li>
           <li class="nav-item">
-            <a href="/concursos" class="nav-link"><i class="bi bi-trophy"></i> Concursos</a>            
+            <a href="/concursos" class="nav-link"><i class="fa-solid fa-trophy"></i> Concursos</a>
           </li>
           <li class="nav-item">
-            <a href="/toros" class="nav-link"><i class="bi bi-bullseye"></i> Toros</a>            
+            <a href="/toros" class="nav-link"><i class="fa-solid fa-bullseye"></i> Toros</a>
           </li>
           <li class="nav-item has-submenu">
-            <a href="#" class="nav-link"><i class="bi bi-info-circle"></i> Servicios</a>
+            <a href="#" class="nav-link"><i class="fa-solid fa-circle-info"></i> Servicios</a>
             <ul class="submenu">
               <li><a href="/servicios/atracciones/" class="submenu-link">Atracciones</a></li>
               <li><a href="/servicios/feria-sin-ruido/" class="submenu-link">Feria sin Ruido</a></li>
@@ -182,7 +182,7 @@
 
   <!-- Scroll to Top Button -->
   <button id="scrollToTop" class="scroll-to-top" aria-label="Subir al inicio">
-    <i class="bi bi-arrow-up-circle-fill"></i>
+    <i class="fa-solid fa-circle-up"></i>
   </button>
 
   <script>

--- a/servicios/atracciones.md
+++ b/servicios/atracciones.md
@@ -2,7 +2,7 @@
 title: Atracciones
 ---
 
-### <i class="bi bi-stars"></i> Atracciones Mecánicas
+### <i class="fa-solid fa-star"></i> Atracciones Mecánicas
 
 **Día de la Infancia**:  
 - **Miércoles 20 de agosto** y **lunes 25 de agosto**

--- a/servicios/feria-sin-ruido.md
+++ b/servicios/feria-sin-ruido.md
@@ -2,7 +2,7 @@
 title: Feria sin ruido
 ---
 
-### <i class="bi bi-volume-mute-fill icono-doble" ></i> Feria sin ruido
+### <i class="fa-solid fa-volume-xmark icono-doble"></i> Feria sin ruido
 
 Para mejorar la accesibilidad de la Feria:
 

--- a/servicios/telefonos.md
+++ b/servicios/telefonos.md
@@ -2,7 +2,7 @@
 title: Teléfonos de interés
 ---
 
-### <i class="bi bi-telephone-fill"></i> Teléfonos útiles durante la feria
+### <i class="fa-solid fa-phone"></i> Teléfonos útiles durante la feria
 
 **Emergencias generales**: [112](tel:112)  
 **Policía Nacional**: [091](tel:091)  

--- a/servicios/tren-turistico.md
+++ b/servicios/tren-turistico.md
@@ -2,7 +2,7 @@
 title: Tren Turístico
 ---
 
-### <i class="bi bi-train-front-fill"></i> Horario del Tren Turístico
+### <i class="fa-solid fa-train"></i> Horario del Tren Turístico
 
 - **Miércoles 20 de agosto**: de 20:00 a 2:00 h  
 - **Jueves 21, viernes 22 y sábado 23**: de 20:00 a 4:00 h  

--- a/toros.md
+++ b/toros.md
@@ -7,32 +7,32 @@ description: Programa completo de los festejos taurinos de la Feria de Agosto 20
 
 ![Cartel taurino Real Feria de Agosto de Antequera 2025](https://storage.googleapis.com/qultura-ficheros/eventos/1b5fc8de-bff9-46f4-9b8a-019e26a53d97.jpg)
 
-# <i class="bi bi-person-arms-up"></i> Sábado 23 de agosto - Gran Corrida del Arte del Rejoneo
+# <i class="fa-solid fa-person-rays"></i> Sábado 23 de agosto - Gran Corrida del Arte del Rejoneo
 
-**<i class="bi bi-geo-alt-fill"></i> Plaza de Toros de Antequera**  
-**<i class="bi bi-clock"></i> Hora:** 19:30 h
+**<i class="fa-solid fa-location-dot"></i> Plaza de Toros de Antequera**
+**<i class="fa-solid fa-clock"></i> Hora:** 19:30 h
 
 ### Cartel
 - **Rejoneadores:** Andy Cartagena y Diego Ventura (mano a mano)
 - **Ganadería:** 6 toros de Prieto de la Cal
 
-### <i class="bi bi-ticket-perforated"></i> Entradas
+### <i class="fa-solid fa-ticket"></i> Entradas
 - **Desde:** 37€
 - **Información y venta:** [www.taurinadebuendia.com](https://www.taurinadebuendia.com)
 - Consultar precios y abonos disponibles
 
 ---
 
-# <i class="bi bi-masks-theater"></i> Domingo 24 de agosto - Tradicional Corrida de Toros Goyesca
+# <i class="fa-solid fa-masks-theater"></i> Domingo 24 de agosto - Tradicional Corrida de Toros Goyesca
 
-**<i class="bi bi-geo-alt-fill"></i> Plaza de Toros de Antequera**  
-**<i class="bi bi-clock"></i> Hora:** 19:30 h
+**<i class="fa-solid fa-location-dot"></i> Plaza de Toros de Antequera**
+**<i class="fa-solid fa-clock"></i> Hora:** 19:30 h
 
 ### Cartel
 - **Matadores:** Curro Díaz, Emilio de Justo y Marco Pérez
 - **Ganaderías:** 6 toros de Núñez del Cuvillo y 3 de Manuel Blázquez
 
-### <i class="bi bi-ticket-perforated"></i> Entradas
+### <i class="fa-solid fa-ticket"></i> Entradas
 - **Desde:** 37€
 - **Información y venta:** [www.taurinadebuenida.com](https://www.taurinadebuendia.com)
 - Consultar precios y abonos disponibles


### PR DESCRIPTION
## Resumen
- Sustituye Bootstrap Icons por Font Awesome en la plantilla principal.
- Actualiza los iconos de navegación y secciones de servicios para usar Font Awesome.
- Ajusta la página de festejos taurinos con nuevos iconos Font Awesome.

## Testing
- `node node_modules/@11ty/eleventy`


------
https://chatgpt.com/codex/tasks/task_e_68989005e24c8330bb81f00bc25bd0c4