### PR TITLE
Replace Caseta Municipal references with Recinto ferial

### DIFF
--- a/programa/2025-08-20.md
+++ b/programa/2025-08-20.md
@@ -41,9 +41,9 @@ title: Miércoles 20 de agosto - Feria de Agosto 2025
 
 ![Juanlu Montoya en concierto](https://storage.googleapis.com/qultura-ficheros/eventos/0e8faf24-95f7-4383-aa1f-576fff95e2bc.jpg){loading="lazy"}
 
-### **Concierto de Los Curros**  
-#### *Hora: 01:30*  
-> El grupo local **Los Curros** se sube al escenario de la Caseta Municipal para poner ritmo a la madrugada de la **Feria de Antequera**.  
+### **Concierto de Los Curros**
+#### *Hora: 01:30*
+> El grupo local **Los Curros** se sube al escenario del Recinto ferial para poner ritmo a la madrugada de la **Feria de Antequera**.
 
 ![Concierto de Los Curros](https://storage.googleapis.com/qultura-ficheros/eventos/f7ac89b4-3570-428b-8da0-e05b5c164336.jpg){loading="lazy"}
 

--- a/programa/2025-08-21.md
+++ b/programa/2025-08-21.md
@@ -33,7 +33,7 @@ title: Jueves 21 de agosto - Feria de Agosto 2025
 
 ---
 
-# Caseta Municipal
+# Recinto ferial
 
 ### **Sesión de DJ Guille Castro**  
 #### *Hora: 21:00*  

--- a/programa/2025-08-22.md
+++ b/programa/2025-08-22.md
@@ -27,7 +27,7 @@ title: Viernes 22 de agosto - Feria de Agosto 2025
 
 ---
 
-# Caseta Municipal
+# Recinto ferial
 
 ### **Sesión de DJ Fran Podadera**  
 #### *Hora: 21:00*  

--- a/programa/2025-08-23.md
+++ b/programa/2025-08-23.md
@@ -27,7 +27,7 @@ title: Sábado 23 de agosto - Feria de Agosto 2025
 
 ---
 
-# Caseta Municipal
+# Recinto ferial
 
 ### **Pepe y Vizio en concierto**  
 #### *Hora: 24:00*  

--- a/programa/2025-08-24.md
+++ b/programa/2025-08-24.md
@@ -19,11 +19,11 @@ title: Domingo 24 de agosto - Feria de Agosto 2025
 
 ---
 
-# Caseta Municipal
+# Recinto ferial
 
 ### **Copla con María José Vegas**  
 #### *Hora: 22:30*  
-> **María José Vegas** nos deleitará con su voz y arte de la copla en la Caseta Municipal, para poner el broche final a la Feria de **Antequera**.  
+> **María José Vegas** nos deleitará con su voz y arte de la copla en el Recinto ferial, para poner el broche final a la Feria de **Antequera**.
 
 ![Copla con María José Vegas](https://storage.googleapis.com/qultura-ficheros/eventos/2e921ce3-d768-41cb-bef1-4f84957cf1e0.jpg){loading="lazy"}
 


### PR DESCRIPTION
## Summary
- Update program entries from Aug 20-24 to reference "Recinto ferial" instead of "Caseta Municipal".

## Testing
- `npx @11ty/eleventy`

------
https://chatgpt.com/codex/tasks/task_e_6898c80ea7248330b40a6288b585f405