### PR TITLE
Add ChatGPT page and update footer layout

### DIFF
--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -155,7 +155,10 @@
               <li><a href="/servicios/telefonos/" class="submenu-link">Teléfonos</a></li>
               <li><a href="/servicios/tren-turistico/" class="submenu-link">Tren Turístico</a></li>
             </ul>
-          </li>          
+          </li>
+          <li class="nav-item">
+            <a href="/chatgpt/" class="nav-link"><i class="fa-brands fa-openai"></i> Consulta nuestro ChatGPT</a>
+          </li>
         </ul>
       </div>
     </nav>
@@ -169,13 +172,13 @@
     <footer class="site-footer">
       <div class="footer-content">
         <div class="footer-section">
-          <h3>Real Feria de Agosto 2025</h3>
-          <p><a href="/legal/">Aviso Legal</a></p>
           <p><a href="https://chatgpt.com/g/g-689908be4b6881918ee2ae1e923a1f9b-real-feria-de-agosto-antequera-2025" target="_blank"><i class="fa-brands fa-openai"></i> Consulta nuestro ChatGPT</a></p>
         </div>
         <div class="footer-section">
-          <p class="copyright"><a href="https://whatsapp.com/channel/0029VadyMAMJuyAKnL83rd0i" target="_blank">Antequera, con Q de Qultura</a></p>
-          <p class="year">Antequera 2025</p>
+          <p><a href="/legal/">Aviso Legal</a></p>
+        </div>
+        <div class="footer-section">
+          <p><a href="https://whatsapp.com/channel/0029VadyMAMJuyAKnL83rd0i" target="_blank"><i class="fa-solid fa-q"></i> Antequera, con Q de Qultura</a></p>
         </div>
       </div>
     </footer>

--- a/chatgpt.md
+++ b/chatgpt.md
@@ -1,0 +1,10 @@
+---
+title: Consulta nuestro ChatGPT
+layout: layout.njk
+---
+
+### Toda la feria de agosto en ChatGPT
+
+Hemos creado un chatGPT personalizado con toda la información de la Feria.
+
+<p><a href="https://chatgpt.com/g/g-689908be4b6881918ee2ae1e923a1f9b-real-feria-de-agosto-antequera-2025" target="_blank"><i class="fa-brands fa-openai"></i> Accede al ChatGPT de la Feria</a></p>

--- a/css/style.css
+++ b/css/style.css
@@ -394,28 +394,20 @@ h6 { font-size: 1rem; }
   max-width: 800px;
   margin: 0 auto;
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(3, 1fr);
   gap: 2rem;
   text-align: center;
 }
 
-.footer-section h3 {
-  font-family: 'Bebas Neue', sans-serif;
-  color: white;
-  margin-bottom: 0.5rem;
-}
 .footer-section a{
-    color: white;
-    text-decoration: none;
-}
-
-.copyright {
-  font-weight: bold;
-}
-
-.year {
-  font-style: italic;
   color: white;
+  text-decoration: none;
+}
+
+@media (max-width: 768px) {
+  .footer-content {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* Responsive Design */


### PR DESCRIPTION
## Summary
- add navigation link and new section for custom ChatGPT
- redesign footer with three responsive links
- adjust footer styling for desktop and mobile

## Testing
- `npx @11ty/eleventy`


------
https://chatgpt.com/codex/tasks/task_e_689991431e608330a961fa779811f063