### PR TITLE
Añade texto MENU al menú móvil

### DIFF
--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -123,9 +123,12 @@
     <nav class="menu-principal">
       <div class="nav-container">
         <button class="menu-toggle" aria-label="Abrir menú">
-          <span></span>
-          <span></span>
-          <span></span>
+          <span class="icon">
+            <span></span>
+            <span></span>
+            <span></span>
+          </span>
+          <span class="menu-text">MENU</span>
         </button>
         <ul class="nav-menu">
           <li class="nav-item has-submenu">

--- a/css/style.css
+++ b/css/style.css
@@ -165,15 +165,26 @@ h6 { font-size: 1rem; }
   border: none;
   cursor: pointer;
   padding: 1rem 0;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.menu-toggle .icon {
+  display: flex;
   flex-direction: column;
   gap: 4px;
 }
 
-.menu-toggle span {
+.menu-toggle .icon span {
   width: 25px;
   height: 3px;
   background: var(--color-primary);
   transition: all 0.3s ease;
+}
+
+.menu-text {
+  color: var(--color-primary);
+  font-weight: 700;
 }
 
 .nav-menu {
@@ -484,15 +495,15 @@ h6 { font-size: 1rem; }
     padding-left: 2.5rem;
   }
   
-  .menu-toggle.active span:nth-child(1) {
+  .menu-toggle.active .icon span:nth-child(1) {
     transform: rotate(45deg) translate(5px, 5px);
   }
-  
-  .menu-toggle.active span:nth-child(2) {
+
+  .menu-toggle.active .icon span:nth-child(2) {
     opacity: 0;
   }
-  
-  .menu-toggle.active span:nth-child(3) {
+
+  .menu-toggle.active .icon span:nth-child(3) {
     transform: rotate(-45deg) translate(7px, -6px);
   }
   


### PR DESCRIPTION
## Summary
- Muestra la palabra MENU junto al icono de navegación en móviles
- Ajusta estilos y animaciones del botón del menú

## Testing
- `node node_modules/@11ty/eleventy/cmd.cjs`
- `npm test` *(falla: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a2cc75a31483309ef1deb1cce4b739